### PR TITLE
Юнит-тесты для публикации

### DIFF
--- a/src/AlphaTest.Core/Tests/Publishing/ProposalStatus.cs
+++ b/src/AlphaTest.Core/Tests/Publishing/ProposalStatus.cs
@@ -6,12 +6,12 @@ namespace AlphaTest.Core.Tests.Publishing
     {
         private ProposalStatus(int id, string name):base(id, name) { }
 
-        public static ProposalStatus NEW = new(1, "Новая");
+        public static readonly ProposalStatus NEW = new(1, "Новая");
 
-        public static ProposalStatus PENDING = new(2, "В работе");
+        public static readonly ProposalStatus PENDING = new(2, "В работе");
 
-        public static ProposalStatus APPROVED = new(3, "Одобрена");
+        public static readonly ProposalStatus APPROVED = new(3, "Одобрена");
 
-        public static ProposalStatus DECLINED = new(4, "Отклонена");
+        public static readonly ProposalStatus DECLINED = new(4, "Отклонена");
     }
 }

--- a/src/AlphaTest.Core/Tests/Publishing/Rules/ProposalMustBeProvidedForPublishingRule.cs
+++ b/src/AlphaTest.Core/Tests/Publishing/Rules/ProposalMustBeProvidedForPublishingRule.cs
@@ -1,0 +1,18 @@
+﻿using AlphaTest.Core.Common;
+
+namespace AlphaTest.Core.Tests.Publishing.Rules
+{
+    public class ProposalMustBeProvidedForPublishingRule : IBusinessRule
+    {
+        private readonly PublishingProposal _proposal;
+
+        public ProposalMustBeProvidedForPublishingRule(PublishingProposal proposal)
+        {
+            _proposal = proposal;
+        }
+
+        public string Message => "Для публикации теста необходимо предоставить заявку";
+
+        public bool IsBroken => _proposal is null;
+    }
+}

--- a/src/AlphaTest.Core/Tests/Publishing/Rules/PublishingOfTestRequiresApprovedProposalRule.cs
+++ b/src/AlphaTest.Core/Tests/Publishing/Rules/PublishingOfTestRequiresApprovedProposalRule.cs
@@ -1,0 +1,23 @@
+﻿using AlphaTest.Core.Common;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AlphaTest.Core.Tests.Publishing.Rules
+{
+    public class PublishingOfTestRequiresApprovedProposalRule : IBusinessRule
+    {
+        private readonly PublishingProposal _proposal;
+
+        public PublishingOfTestRequiresApprovedProposalRule(PublishingProposal proposal)
+        {
+            _proposal = proposal;
+        }
+
+        public string Message => $"Заявка на публикацию должна быть одобрена, текущий статус заявки - {_proposal.Status}.";
+
+        public bool IsBroken => _proposal.Status != ProposalStatus.APPROVED;
+    }
+}

--- a/src/AlphaTest.Core/Tests/Publishing/Rules/QuestionListMustNotBeEmptyBeforePublishingRule.cs
+++ b/src/AlphaTest.Core/Tests/Publishing/Rules/QuestionListMustNotBeEmptyBeforePublishingRule.cs
@@ -4,7 +4,7 @@ using AlphaTest.Core.Tests.Questions;
 
 namespace AlphaTest.Core.Tests.Publishing.Rules
 {
-    class QuestionListMustNotBeEmptyBeforePublishingRule : IBusinessRule
+    public class QuestionListMustNotBeEmptyBeforePublishingRule : IBusinessRule
     {
         private readonly List<Question> _allQuestionsInTest;
 

--- a/src/AlphaTest.Core/Tests/Publishing/Rules/TestMustBeProposedForPublishingBeforeBeingPublishedRule.cs
+++ b/src/AlphaTest.Core/Tests/Publishing/Rules/TestMustBeProposedForPublishingBeforeBeingPublishedRule.cs
@@ -1,0 +1,19 @@
+﻿using AlphaTest.Core.Common;
+
+namespace AlphaTest.Core.Tests.Publishing.Rules
+{
+    public class TestMustBeProposedForPublishingBeforeBeingPublishedRule : IBusinessRule
+    {
+        private readonly TestStatus _status;
+
+        public TestMustBeProposedForPublishingBeforeBeingPublishedRule(TestStatus status)
+        {
+            _status = status;
+        }
+
+        // ToDo придумать более ясное сообщение
+        public string Message => "Перед публикацией тест должен пройти проверку.";
+
+        public bool IsBroken => _status != TestStatus.WaitingForPublishing;
+    }
+}

--- a/src/AlphaTest.Core/Tests/Test.cs
+++ b/src/AlphaTest.Core/Tests/Test.cs
@@ -203,10 +203,11 @@ namespace AlphaTest.Core.Tests
             return new PublishingProposal(this.ID);
         }
 
-        public void Publish()
+        public void Publish(PublishingProposal approvedProposal)
         {
-            // ToDo временная реализация
-            // ToDo на вход нужно передавать отработанную заявку
+            CheckRule(new TestMustBeProposedForPublishingBeforeBeingPublishedRule(this.Status));
+            CheckRule(new ProposalMustBeProvidedForPublishingRule(approvedProposal));
+            CheckRule(new PublishingOfTestRequiresApprovedProposalRule(approvedProposal));
             Status = TestStatus.Published;
         }
 

--- a/src/AlphaTest.Core/Tests/TestStatus.cs
+++ b/src/AlphaTest.Core/Tests/TestStatus.cs
@@ -10,8 +10,8 @@ namespace AlphaTest.Core.Tests
 
         public static readonly TestStatus WaitingForPublishing = new(2, "В ожидании публикации");
 
-        public static readonly TestStatus Published = new TestStatus(3, "Опубликован");
+        public static readonly TestStatus Published = new (3, "Опубликован");
 
-        public static readonly TestStatus Archived = new TestStatus(4, "В архиве");
+        public static readonly TestStatus Archived = new (4, "В архиве");
     }
 }

--- a/src/Tests/AlphaTest.Core.UnitTests/Common/Helpers/HelpersForTests.cs
+++ b/src/Tests/AlphaTest.Core.UnitTests/Common/Helpers/HelpersForTests.cs
@@ -1,0 +1,40 @@
+﻿using AlphaTest.Core.Tests;
+using AlphaTest.TestingHelpers;
+using Moq;
+using System.Reflection;
+using System;
+
+namespace AlphaTest.Core.UnitTests.Common.Helpers
+{
+    public static class HelpersForTests
+    {
+        // ToDo заменить все GetDefaultTest на вызов этого метода
+        public static Test GetDefaultTest()
+        {
+            string title = It.IsAny<string>();
+            string topic = It.IsAny<string>();
+            int authorID = It.IsAny<int>();
+            var testCounterMock = new Mock<ITestCounter>();
+            testCounterMock
+                .Setup(
+                    c => c.GetQuantityOfTests(title, topic, Test.INITIAL_VERSION, authorID)
+                )
+                .Returns(0);
+            Test defaultTest = new(title, topic, authorID, testCounterMock.Object);
+            EntityIDSetter.SetIDTo(defaultTest, 1);
+            return defaultTest;
+        }
+
+        public static void SetNewStatusForTest(Test test, TestStatus status)
+        {
+            if (test is null)
+                throw new ArgumentNullException(nameof(test));
+            if (status is null)
+                throw new ArgumentNullException(nameof(status));
+            var property = test.GetType().GetProperty("Status", BindingFlags.Public | BindingFlags.Instance);
+            if (property is null)
+                throw new InvalidOperationException($"Свойство Status не найдено у типа {test.GetType()}.");
+            property.SetValue(test, status, null);
+        }
+    }
+}

--- a/src/Tests/AlphaTest.Core.UnitTests/Common/UnitTestBase.cs
+++ b/src/Tests/AlphaTest.Core.UnitTests/Common/UnitTestBase.cs
@@ -7,8 +7,9 @@ namespace AlphaTest.Core.UnitTests.Common
 {
     public abstract class UnitTestBase
     {
-        public void AssertBrokenRule<TRule>(Action testAction) where TRule : class, IBusinessRule
+        public static void AssertBrokenRule<TRule>(Action testAction) where TRule : class, IBusinessRule
         {
+            // ToDo если нет ошибки - одно сообщение, если нарушено другое правило - другое сообщение
             string message = $"Правило {typeof(TRule).Name} не было нарушено.";
             BusinessException exception = Assert.Throws<BusinessException>(testAction);
             if (exception is not null)

--- a/src/Tests/AlphaTest.Core.UnitTests/Testmaking/Publishing/PublishingTests.cs
+++ b/src/Tests/AlphaTest.Core.UnitTests/Testmaking/Publishing/PublishingTests.cs
@@ -1,0 +1,179 @@
+﻿using System;
+using System.Reflection;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using AlphaTest.Core.UnitTests.Common;
+using AlphaTest.Core.UnitTests.Common.Helpers;
+using AlphaTest.Core.UnitTests.Testmaking.Questions;
+using AlphaTest.Core.Tests;
+using AlphaTest.Core.Tests.Publishing;
+using AlphaTest.Core.Tests.Publishing.Rules;
+using AlphaTest.Core.Tests.Questions;
+
+
+namespace AlphaTest.Core.UnitTests.Testmaking.Publishing
+{
+
+    public class PublishingTests: UnitTestBase
+    {
+        [Theory]
+        [MemberData(nameof(NonDraftTestStatuses))]
+        public void Non_draft_tests_cannot_be_proposed_for_publishing(TestStatus status)
+        {
+            Test test = HelpersForTests.GetDefaultTest();
+            // статус устанавливаем через рефлексию, так как не важно, каким образом этот статус был достигнут
+            // для установки обычным путём нужно много операций
+            HelpersForTests.SetNewStatusForTest(test, status);
+            AssertBrokenRule<OnlyDraftTestsCanBeProposedForPublishingRule>(() =>
+                test.ProposeForPublishing(new List<Question>())
+            );
+
+        }
+
+        [Fact]
+        public void Test_without_questions_cannot_be_proposed_for_publishing()
+        {
+            Test test = HelpersForTests.GetDefaultTest();
+            AssertBrokenRule<QuestionListMustNotBeEmptyBeforePublishingRule>(() =>
+                test.ProposeForPublishing(new List<Question>())
+            );
+        }
+
+        [Fact]
+        public void Test_with_unachievable_score_cannot_be_proposed_for_publishing()
+        {
+            Test test = HelpersForTests.GetDefaultTest();
+            QuestionTestData data = new() { Test = test, Score = new(10) };
+            SingleChoiceQuestion question = QuestionTestSamples.CreateSingleChoiceQuestion(data) as SingleChoiceQuestion;
+            test.ChangePassingScore(1000);
+            AssertBrokenRule<PassingScoreMustBeAchievableRule>(() =>
+                test.ProposeForPublishing(new List<Question>() { question })
+            );
+        }
+
+        [Fact]
+        public void Draft_test_with_questions_and_realistic_score_can_be_proposed_for_publishing()
+        {
+            Test test = HelpersForTests.GetDefaultTest();
+            QuestionTestData data = new() { Test = test, Score = new(10) };
+            SingleChoiceQuestion question = QuestionTestSamples.CreateSingleChoiceQuestion(data) as SingleChoiceQuestion;
+            test.ChangePassingScore(10);
+            PublishingProposal proposal = test.ProposeForPublishing(new List<Question>() { question });
+
+            Assert.Equal(test.ID, proposal.TestID);
+            Assert.Equal(test.Status, TestStatus.WaitingForPublishing);
+        }
+
+        [Fact]
+        public void Publishing_proposal_cannot_be_declined_without_remark()
+        {
+            Test test = HelpersForTests.GetDefaultTest();
+            QuestionTestData data = new() { Test = test, Score = new(10) };
+            SingleChoiceQuestion question = QuestionTestSamples.CreateSingleChoiceQuestion(data) as SingleChoiceQuestion;
+            test.ChangePassingScore(10);
+            PublishingProposal proposal = test.ProposeForPublishing(new List<Question>() { question });
+
+            AssertBrokenRule<RemarkMustBeProvidedWhenProposalIsDeclinedRule>(() =>
+                proposal.Decline("    ")
+            );
+        }
+
+        [Fact]
+        public void Publishing_proposal_can_be_declined_with_remark()
+        {
+            Test test = HelpersForTests.GetDefaultTest();
+            QuestionTestData data = new() { Test = test, Score = new(10) };
+            SingleChoiceQuestion question = QuestionTestSamples.CreateSingleChoiceQuestion(data) as SingleChoiceQuestion;
+            test.ChangePassingScore(10);
+            PublishingProposal proposal = test.ProposeForPublishing(new List<Question>() { question });
+
+            proposal.Decline("Текст замечания");
+
+            Assert.Equal(ProposalStatus.DECLINED, proposal.Status);
+            // ToDo check domain event
+        }
+
+        [Fact]
+        public void Test_must_be_in_waiting_mode_before_publishing()
+        {
+            Test test = HelpersForTests.GetDefaultTest();
+            AssertBrokenRule<TestMustBeProposedForPublishingBeforeBeingPublishedRule>(() =>
+                test.Publish(null)
+            );
+        }
+
+        [Fact]
+        public void Publishing_proposal_must_be_provided_for_publishing()
+        {
+            Test test = HelpersForTests.GetDefaultTest();
+            QuestionTestData data = new() { Test = test, Score = new(10) };
+            SingleChoiceQuestion question = QuestionTestSamples.CreateSingleChoiceQuestion(data) as SingleChoiceQuestion;
+            test.ChangePassingScore(10);
+            PublishingProposal proposal = test.ProposeForPublishing(new List<Question>() { question });
+
+            AssertBrokenRule<ProposalMustBeProvidedForPublishingRule>(() =>
+                test.Publish(null)
+            );
+        }
+
+        [Theory]
+        [MemberData(nameof(NonApprovedProposalStatuses))]
+        public void Publishing_test_requires_approved_proposal(ProposalStatus status)
+        {
+            Test test = HelpersForTests.GetDefaultTest();
+            QuestionTestData data = new() { Test = test, Score = new(10) };
+            SingleChoiceQuestion question = QuestionTestSamples.CreateSingleChoiceQuestion(data) as SingleChoiceQuestion;
+            test.ChangePassingScore(10);
+            PublishingProposal proposal = test.ProposeForPublishing(new List<Question>() { question });
+
+            SetProposalStatus(proposal, status);
+
+            AssertBrokenRule<PublishingOfTestRequiresApprovedProposalRule>(() =>
+                test.Publish(proposal)
+            );
+        }
+
+        [Fact]
+        public void Test_can_be_published_with_approved_proposal()
+        {
+            Test test = HelpersForTests.GetDefaultTest();
+            QuestionTestData data = new() { Test = test, Score = new(10) };
+            SingleChoiceQuestion question = QuestionTestSamples.CreateSingleChoiceQuestion(data) as SingleChoiceQuestion;
+            test.ChangePassingScore(10);
+            PublishingProposal proposal = test.ProposeForPublishing(new List<Question>() { question });
+
+            SetProposalStatus(proposal, ProposalStatus.APPROVED);
+            test.Publish(proposal);
+
+            Assert.Equal(TestStatus.Published, test.Status);
+            // ToDo check domain event
+        }
+
+        public static IEnumerable<object[]> NonDraftTestStatuses() =>
+            TestStatus
+            .All
+            .Where(s => s != TestStatus.Draft)
+            .Select(s => new object[] { s })
+            .ToList();
+
+        public static IEnumerable<object[]> NonApprovedProposalStatuses() =>
+            ProposalStatus
+            .All
+            .Where(s => s != ProposalStatus.APPROVED)
+            .Select(s => new object[] { s })
+            .ToList();
+
+        private static void SetProposalStatus(PublishingProposal proposal, ProposalStatus status)
+        {
+            if (proposal is null)
+                throw new ArgumentNullException(nameof(proposal));
+            if (status is null)
+                throw new ArgumentNullException(nameof(status));
+            var property = proposal.GetType().GetProperty("Status", BindingFlags.Public | BindingFlags.Instance);
+            if (property is null)
+                throw new InvalidOperationException($"Свойство Status не найдено у типа {proposal.GetType()}.");
+            property.SetValue(proposal, status);
+        }
+    }
+}

--- a/src/Tests/AlphaTest.Core.UnitTests/Testmaking/TestmakingTests.cs
+++ b/src/Tests/AlphaTest.Core.UnitTests/Testmaking/TestmakingTests.cs
@@ -10,6 +10,7 @@ using AlphaTest.Core.UnitTests.Common;
 using AlphaTest.Core.Tests.TestSettings.TestFlow;
 using AlphaTest.Core.Tests.Questions;
 using AlphaTest.Core.UnitTests.Testmaking.Questions;
+using AlphaTest.Core.UnitTests.Common.Helpers;
 
 namespace AlphaTest.Core.UnitTests.Testmaking
 {
@@ -144,7 +145,7 @@ namespace AlphaTest.Core.UnitTests.Testmaking
         public void EditAnySettings_WhenTestIsPublished_IsNotPossible(Action<Test> editingDelegate)
         {
             Test test = MakeDefaultTest();
-            test.Publish();
+            HelpersForTests.SetNewStatusForTest(test, TestStatus.Published);
             AssertBrokenRule<NonDraftTestCannotBeEditedRule>(() => editingDelegate(test));
         }
 
@@ -155,7 +156,7 @@ namespace AlphaTest.Core.UnitTests.Testmaking
             // ToDo выглядит плохо, надо будет исправить
             // MAYBE перенести в тесты для вопросов
             QuestionTestData data = new();
-            data.Test.Publish();
+            HelpersForTests.SetNewStatusForTest(data.Test, TestStatus.Published);
             AssertBrokenRule<NonDraftTestCannotBeEditedRule>(() => addQuestionDelegate(data));
         }
         


### PR DESCRIPTION
Добавлены юнит-тесты для публикации теста и для отправки заявки на публикацию;
Правка старых тестов под изменившееся поведение;
Мелкие правки для перечислений и некоторых базовых классов - линтинг.